### PR TITLE
error message removed when receiving `user h h h : h` instead of `use…

### DIFF
--- a/srcs/commands/USER.cpp
+++ b/srcs/commands/USER.cpp
@@ -19,6 +19,9 @@ void    setUser(std::string params, User &user)
     formattedParams = removeConsecutiveWhitespace(params);
     splittedParams = splitString(formattedParams);
      
+    if (splittedParams.size() > 4 )
+        return ;
+        
     if (splittedParams.size() < 4 || splittedParams[3].size() < 2)
     {
         errorMessage = sendMessage1(461, user, *(user.getServer()), "USER");


### PR DESCRIPTION
…r h h h :h`